### PR TITLE
Allow setting engine parameters via cmd arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 chess>=1.7.0
 scipy>=1.4.0
+pillow


### PR DESCRIPTION
This allows for easy setting of e.g. stockfish executable path or thread count w/o changing the code.

I tried to integrate it w/o major changes, making use of the already existing global values. It's not pretty, but simple.
If you want a more serious solution, just tell me.

I may also add the same change to `AutoPNG.py` if needed.

Also: added the missing requirement to `requirements.txt`.